### PR TITLE
On my system, util.inherit blows away the prototype.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*~

--- a/client.js
+++ b/client.js
@@ -149,6 +149,8 @@ var AlmondDevice = function(client, config) {
     }
 }
 
+util.inherits(AlmondDevice, EventEmitter);
+
 AlmondDevice.prototype.setProp = function(prop, value, cb) {
     var self = this;
 
@@ -186,8 +188,6 @@ AlmondDevice.prototype.updateProp = function(prop, value) {
     this._deviceValues[prop].value = value;
     this.emit("valueUpdated", prop, value);
 }
-
-util.inherits(AlmondDevice, EventEmitter);
 
 var WebSocketEmitter = function() {
     EventEmitter.call(this);


### PR DESCRIPTION
Calling inherit before adding methods works.